### PR TITLE
exemplar wip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,8 +1472,7 @@ dependencies = [
 [[package]]
 name = "prometheus"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
+source = "git+https://github.com/clux/rust-prometheus.git?rev=c9f7ea9652e27cd2d872937c5efbe72f20db0d5e#c9f7ea9652e27cd2d872937c5efbe72f20db0d5e"
 dependencies = [
  "cfg-if",
  "fnv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,9 +18,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.0.0-beta.3"
+version = "3.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a12706e793a92377f85cec219514b72625b3b89f9b4912d8bfb53ab6a615bf0"
+checksum = "59d51c2ba06062e698a5d212d860e9fb2afc931c285ede687aaae896c8150347"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -33,33 +33,31 @@ dependencies = [
  "brotli2",
  "bytes",
  "bytestring",
- "cookie",
  "derive_more",
  "encoding_rs",
  "flate2",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
  "http",
  "httparse",
- "indexmap",
  "itoa",
  "language-tags",
- "lazy_static",
+ "local-channel",
  "log",
  "mime",
+ "once_cell",
+ "paste",
  "percent-encoding",
  "pin-project 1.0.5",
+ "pin-project-lite",
  "rand",
  "regex",
  "serde",
- "serde_json",
- "serde_urlencoded",
  "sha-1",
- "slab",
  "smallvec",
  "time 0.2.25",
+ "tokio",
 ]
 
 [[package]]
@@ -87,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b4e57bc1a3915e71526d128baf4323700bd1580bc676239e2298a4c5b001f18"
+checksum = "bc7d7cd957c9ed92288a7c3c96af81fa5291f65247a76a34dac7b6af74e52ba0"
 dependencies = [
  "actix-macros",
  "futures-core",
@@ -116,19 +114,20 @@ dependencies = [
 
 [[package]]
 name = "actix-service"
-version = "2.0.0-beta.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca9756f4d32984ac454ae3155a276f6be69b424197bd3f0ca3c87cde72f41d63"
+checksum = "77f5f9d66a8730d0fae62c26f3424f5751e5518086628a40b7ab6fca4a705034"
 dependencies = [
  "futures-core",
+ "paste",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "actix-tls"
-version = "3.0.0-beta.4"
+version = "3.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b1455e3f7a26d40cfc1080b571f41e8165e5a88e937ed579f7a4b3d55b0370"
+checksum = "65b7bb60840962ef0332f7ea01a57d73a24d2cb663708511ff800250bbfef569"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -143,24 +142,19 @@ dependencies = [
 
 [[package]]
 name = "actix-utils"
-version = "3.0.0-beta.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458795e09a29bc5557604f9ff6f32236fd0ee457d631672e4ec8f6a0103bb292"
+checksum = "e491cbaac2e7fc788dfff99ff48ef317e23b3cf63dbaf7aaab6418f40f92aa94"
 dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-service",
- "futures-core",
- "futures-sink",
- "log",
+ "local-waker",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "actix-web"
-version = "4.0.0-beta.3"
+version = "4.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9683dc8c3037ea524e0fec6032d34e1cb1ee72c4eb8689f428a60c2a544ea3"
+checksum = "ff12e933051557d700b0fcad20fe25b9ca38395cc87bbc5aeaddaef17b937a2f"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -172,31 +166,34 @@ dependencies = [
  "actix-utils",
  "actix-web-codegen",
  "ahash",
- "awc",
  "bytes",
+ "cookie",
  "derive_more",
  "either",
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "itoa",
+ "language-tags",
  "log",
  "mime",
+ "once_cell",
  "pin-project 1.0.5",
  "regex",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.3.19",
+ "socket2 0.4.0",
  "time 0.2.25",
  "url",
 ]
 
 [[package]]
 name = "actix-web-codegen"
-version = "0.5.0-beta.1"
+version = "0.5.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8313dc4cbcae1785a7f14c3dfb7dfeb25fe96a03b20e5c38fe026786def5aa70"
+checksum = "7f138ac357a674c3b480ddb7bbd894b13c1b6e8927d728bc9ea5e17eee2f8fc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -281,30 +278,6 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
-name = "awc"
-version = "3.0.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7225ad81fbad09ef56ccc61e0688abe8494a68722c5d0df5e2fc8b724a200b"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-rt",
- "actix-service",
- "base64",
- "bytes",
- "cfg-if",
- "derive_more",
- "futures-core",
- "log",
- "mime",
- "percent-encoding",
- "rand",
- "serde",
- "serde_json",
- "serde_urlencoded",
-]
 
 [[package]]
 name = "base-x"
@@ -424,6 +397,7 @@ dependencies = [
  "kube",
  "kube-runtime",
  "maplit",
+ "mime",
  "opentelemetry",
  "opentelemetry-otlp",
  "prometheus",
@@ -440,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
+checksum = "ffdf8865bac3d9a3bde5bde9088ca431b11f5d37c7a578b8086af77248b76627"
 dependencies = [
  "percent-encoding",
  "time 0.2.25",
@@ -825,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
  "bytes",
  "fnv",
@@ -1099,6 +1073,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
+name = "local-channel"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6246c68cf195087205a0512559c97e15eaf95198bf0e206d662092cdcb03fe9f"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "local-waker",
+]
+
+[[package]]
+name = "local-waker"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84f9a2d3e27ce99ce2c3aad0b09b1a7b916293ea9b2bf624c13fe646fadd8da4"
+
+[[package]]
 name = "lock_api"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,6 +1350,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+
+[[package]]
 name = "pem"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,7 +1470,7 @@ dependencies = [
 [[package]]
 name = "prometheus"
 version = "0.12.0"
-source = "git+https://github.com/clux/rust-prometheus.git?rev=c9f7ea9652e27cd2d872937c5efbe72f20db0d5e#c9f7ea9652e27cd2d872937c5efbe72f20db0d5e"
+source = "git+https://github.com/clux/rust-prometheus.git?branch=master#539f5c031b216d9009d2e898e26cb96df837c391"
 dependencies = [
  "cfg-if",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,10 @@ tracing-subscriber = { version = "0.2.18", features = ["json"] }
 tracing-opentelemetry = "0.12.0"
 opentelemetry = { version = "0.13.0", features = ["trace", "rt-tokio"] }
 opentelemetry-otlp = { version = "0.6.0", features = ["tokio"] }
-prometheus = "0.12.0"
+#prometheus = "0.12.0"
 
 # exemplar support (broken atm)
-#prometheus = { git = "https://github.com/clux/rust-prometheus.git", rev = "c9f7ea9652e27cd2d872937c5efbe72f20db0d5e" }
+prometheus = { git = "https://github.com/clux/rust-prometheus.git", rev = "c9f7ea9652e27cd2d872937c5efbe72f20db0d5e" }
 
 # local dev
 #kube = { path = "../kube-rs/kube", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ telemetry = []
 
 [dependencies]
 actix-rt = "2.1.0"
-actix-web = "4.0.0-beta.1"
+actix-web = "4.0.0-beta.6"
 futures = "0.3.15"
 tokio = { version = "1.6.0", features = ["macros"] }
 kube = { version = "0.56.0", features = ["derive"] }
@@ -45,8 +45,8 @@ opentelemetry = { version = "0.13.0", features = ["trace", "rt-tokio"] }
 opentelemetry-otlp = { version = "0.6.0", features = ["tokio"] }
 #prometheus = "0.12.0"
 
-# exemplar support (broken atm)
-prometheus = { git = "https://github.com/clux/rust-prometheus.git", rev = "c9f7ea9652e27cd2d872937c5efbe72f20db0d5e" }
+# exemplar support
+prometheus = { git = "https://github.com/clux/rust-prometheus.git", branch = "master" }
 
 # local dev
 #kube = { path = "../kube-rs/kube", features = ["derive"] }
@@ -54,3 +54,4 @@ prometheus = { git = "https://github.com/clux/rust-prometheus.git", rev = "c9f7e
 #kube = { git = "https://github.com/clux/kube-rs.git", rev = "698f421652032aec5302eefa1593a4bee0d28b77", features = ["derive"] }
 #kube-runtime = { git = "https://github.com/clux/kube-rs.git", rev = "698f421652032aec5302eefa1593a4bee0d28b77" }
 #prometheus = { path = "../rust-prometheus" }
+mime = "0.3.16"

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,10 @@ tag-semver: build
 	fi
 
 # Helpers for using tempo as an otel collector
-forward-tempo:
+forward-tempo-agent:
 	kubectl port-forward -n monitoring service/grafana-agent-traces 55680:55680
+forward-tempo-chart:
+	kubectl port-forward -n monitoring service/promstack-tempo 55680:4317
 forward-tempo-metrics:
 	kubectl port-forward -n monitoring service/grafana-agent-traces 8080:8080
 check-tempo-metrics:

--- a/local-service.yaml
+++ b/local-service.yaml
@@ -5,9 +5,8 @@ metadata:
   name: foo-controller-local
   namespace: default
   annotations:
-    prometheus.io/scrape: enabled
-    prometheus.io/port: '8080'
-    prometheus.io/scheme: 'http'
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
   labels:
     app: foo-controller
 spec:

--- a/local-service.yaml
+++ b/local-service.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: foo-controller-local
+  namespace: default
+  annotations:
+    prometheus.io/scrape: enabled
+    prometheus.io/port: '8080'
+    prometheus.io/scheme: 'http'
+  labels:
+    app: foo-controller
+spec:
+ type: ClusterIP
+ ports:
+ - name: http
+   port: 8080
+   targetPort: 8080
+   protocol: TCP
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+ name: foo-controller-local
+ namespace: default
+subsets:
+- addresses:
+    - ip: 192.168.1.246
+  ports:
+    - port: 8080
+      name: http

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use actix_web::{
 
 #[get("/metrics")]
 async fn metrics(c: Data<Manager>, _req: HttpRequest) -> impl Responder {
+    info!("got scraped!");
     let metrics = c.metrics();
     let encoder = TextEncoder::new();
     let mut buffer = vec![];

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use tracing::{debug, error, info, trace, warn};
 use tracing_subscriber::{prelude::*, EnvFilter, Registry};
 
 use actix_web::{
-    get, middleware,
+    get, middleware, http::header,
     web::{self, Data},
     App, HttpRequest, HttpResponse, HttpServer, Responder,
 };
@@ -17,7 +17,11 @@ async fn metrics(c: Data<Manager>, _req: HttpRequest) -> impl Responder {
     let encoder = TextEncoder::new();
     let mut buffer = vec![];
     encoder.encode(&metrics, &mut buffer).unwrap();
-    HttpResponse::Ok().body(buffer)
+
+    let mime = "application/openmetrics-text; version=1.0.0; charset=utf-8".parse::<mime::Mime>().unwrap();
+    HttpResponse::Ok()
+        .insert_header(header::ContentType(mime))
+        .body(buffer)
 }
 
 #[get("/health")]

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -11,7 +11,7 @@ use kube_runtime::controller::{Context, Controller, ReconcilerAction};
 use maplit::hashmap;
 use prometheus::{
     default_registry, proto::MetricFamily, register_histogram_vec, register_int_counter,
-    HistogramOpts, HistogramVec, IntCounter,
+    HistogramOpts, HistogramVec, IntCounter, Exemplar
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -76,13 +76,12 @@ async fn reconcile(foo: Foo, ctx: Context<Data>) -> Result<ReconcilerAction, Err
         .map_err(Error::KubeError)?;
 
     let duration = start.elapsed().as_millis() as f64 / 1000.0;
-    //let ex = Exemplar::new_with_labels(duration, hashmap! {"trace_id".to_string() => trace_id});
+    let ex = Exemplar::new_with_labels(duration, hashmap! {"trace_id".to_string() => trace_id});
     ctx.get_ref()
         .metrics
         .reconcile_duration
         .with_label_values(&[])
-        .observe(duration);
-        //.observe_with_exemplar(duration, ex);
+        .observe_with_exemplar(duration, ex);
     ctx.get_ref().metrics.handled_events.inc();
     info!("Reconciled Foo \"{}\" in {}", name, ns);
 

--- a/yaml/deployment.yaml
+++ b/yaml/deployment.yaml
@@ -44,6 +44,9 @@ kind: Service
 metadata:
   name: foo-controller
   namespace: default
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
   labels:
     app: foo-controller
 spec:

--- a/yaml/local-test-service.yaml
+++ b/yaml/local-test-service.yaml
@@ -1,3 +1,4 @@
+# This is a testing service to allow my k3d prometheus to scrape local ip
 ---
 apiVersion: v1
 kind: Service
@@ -24,6 +25,7 @@ metadata:
  namespace: default
 subsets:
 - addresses:
+    # my current local ip (used by the service)
     - ip: 192.168.1.246
   ports:
     - port: 8080


### PR DESCRIPTION
set up a local kube-prometheus-stack today (running prometheus 2.27, with `enableFeatures: ['exemplar-storage']` in its `prometheusSpec`)

raised one invalid bug against prometheus (linked below) and found I needed a custom header to use the [open metrics format](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md).

PoC is done. The branch works.