### PR TITLE
upgrade otel dependencies for 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "controller"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
+ "tonic",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -952,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -1341,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff27b33e30432e7b9854936693ca103d8591b0501f7ae9f633de48cda3bf2a67"
+checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -1360,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42168ec1ee8fe85f36600c41196963eb075ccdd0aaac947119f1f562c0804dd"
+checksum = "f19d4b43842433c420c548c985d158f5628bba5b518e0be64627926d19889992"
 dependencies = [
  "async-trait",
  "futures",
@@ -1544,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1554,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes",
  "heck",
@@ -1572,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1585,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes",
  "prost",
@@ -1864,9 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad104641f3c958dab30eb3010e834c2622d1f3f4c530fef1dee20ad9485f3c09"
+checksum = "d8c608a35705a5d3cdc9fbe403147647ff34b921f8e833e49306df898f9b20af"
 dependencies = [
  "dtoa",
  "indexmap",
@@ -2228,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.4.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac42cd97ac6bd2339af5bcabf105540e21e45636ec6fa6aae5e85d44db31be0"
+checksum = "796c5e1cd49905e65dd8e700d4cb1dffcbfdb4fc9d017de08c1a537afd83627c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2242,6 +2243,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-timeout",
  "percent-encoding",
  "pin-project 1.0.5",
  "prost",
@@ -2250,6 +2252,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower",
+ "tower-layer",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -2257,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
+checksum = "12b52d07035516c2b74337d2ac7746075e7dcae7643816c1b12c5ff8a7484c08"
 dependencies = [
  "proc-macro2",
  "prost-build",
@@ -2373,9 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c47440f2979c4cd3138922840eec122e3c0ba2148bc290f756bd7fd60fc97fff"
+checksum = "599f388ecb26b28d9c1b2e4437ae019a7b336018b45ed911458cd9ebf91129f6"
 dependencies = [
  "opentelemetry",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "controller"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["clux <sszynrae@gmail.com>"]
 edition = "2018"
 default-run = "controller"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,14 +38,15 @@ serde_json = "1.0.67"
 chrono = { version = "0.4.19", features = ["serde"] }
 thiserror = "1.0.29"
 schemars = { version = "0.8.3", features = ["chrono"] }
-serde_yaml = "0.8.20"
+serde_yaml = "0.8.21"
 maplit = "1.0.2"
 tracing = "0.1.26"
 tracing-subscriber = { version = "0.2.20", features = ["json"] }
-tracing-opentelemetry = "0.14.0"
-opentelemetry = { version = "0.15.0", features = ["trace", "rt-tokio"] }
-opentelemetry-otlp = { version = "0.8.0", features = ["tokio"] }
+tracing-opentelemetry = "0.15.0"
+opentelemetry = { version = "0.16.0", features = ["trace", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.9.0", features = ["tokio"] }
 prometheus = "0.12.0"
+tonic = "0.5.2"
 
 # exemplar support (broken atm)
 #prometheus = { git = "https://github.com/clux/rust-prometheus.git", rev = "c9f7ea9652e27cd2d872937c5efbe72f20db0d5e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/lib.rs"
 
 [features]
 default = []
-telemetry = []
+telemetry = ["tonic", "opentelemetry-otlp"]
 
 [dependencies]
 actix-rt = "2.2.0"
@@ -44,9 +44,9 @@ tracing = "0.1.26"
 tracing-subscriber = { version = "0.2.20", features = ["json"] }
 tracing-opentelemetry = "0.15.0"
 opentelemetry = { version = "0.16.0", features = ["trace", "rt-tokio"] }
-opentelemetry-otlp = { version = "0.9.0", features = ["tokio"] }
+opentelemetry-otlp = { version = "0.9.0", features = ["tokio"], optional = true }
 prometheus = "0.12.0"
-tonic = "0.5.2"
+tonic = { version = "0.5.2", optional = true }
 
 # exemplar support (broken atm)
 #prometheus = { git = "https://github.com/clux/rust-prometheus.git", rev = "c9f7ea9652e27cd2d872937c5efbe72f20db0d5e" }

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ tag-semver: build
 
 # Helpers for using tempo as an otel collector
 forward-tempo:
-	kubectl port-forward -n monitoring service/grafana-agent-traces 55680:55680
+	kubectl port-forward -n monitoring service/promstack-tempo 55680:55680
 forward-tempo-metrics:
 	kubectl port-forward -n monitoring service/grafana-agent-traces 8080:8080
 check-tempo-metrics:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can either run locally, or build the image and deploy to your cluster.
 ### Local Development
 You need a valid local kube config with rbac privilages described in the [deployment.yaml](./yaml/deployment.yaml). A default `k3d` setup will work.
 
-This setup is the easiest (and fastest) since it can work with just port-forwarding and `cargo run`, but you won't have everything in the cluster at your disposal.
+This setup is the easiest (and fastest) since it can work with just `cargo run` (or port-forward + and set evar first for telemetry feature), but you won't have everything in the cluster at your disposal.
 
 ### In-cluster Development
 Deploy as a deployment with scoped access via a service account. See `yaml/deployment.yaml` as an example. Note that the image on dockerhub is built with the `telemetry` feature (which requires an otel collector).

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,23 +30,20 @@ async fn index(c: Data<Manager>, _req: HttpRequest) -> impl Responder {
     HttpResponse::Ok().json(&state)
 }
 
+#[cfg(feature = "telemetry")]
+async fn init_tracer() -> opentelemetry::sdk::trace::Tracer {
+    let otlp_endpoint =
+        std::env::var("OPENTELEMETRY_ENDPOINT_URL").expect("Need a otel tracing collector configured");
 
-#[actix_rt::main]
-async fn main() -> Result<()> {
-    #[cfg(feature = "telemetry")]
-    let otlp_endpoint = std::env::var("OPENTELEMETRY_ENDPOINT_URL").expect("Need a otel tracing collector configured");
+    let channel = tonic::transport::Channel::from_shared(otlp_endpoint)
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
 
-    #[cfg(feature = "telemetry")]
-    let channel = tonic::transport::Channel::from_shared(otlp_endpoint).unwrap().connect().await.unwrap();
-
-    #[cfg(feature = "telemetry")]
-    let tracer = opentelemetry_otlp::new_pipeline()
+    opentelemetry_otlp::new_pipeline()
         .tracing()
-        .with_exporter(
-            opentelemetry_otlp::new_exporter()
-                .tonic()
-                .with_channel(channel),
-        )
+        .with_exporter(opentelemetry_otlp::new_exporter().tonic().with_channel(channel))
         .with_trace_config(opentelemetry::sdk::trace::config().with_resource(
             opentelemetry::sdk::Resource::new(vec![opentelemetry::KeyValue::new(
                 "service.name",
@@ -54,23 +51,26 @@ async fn main() -> Result<()> {
             )]),
         ))
         .install_batch(opentelemetry::runtime::Tokio)
-        .unwrap();
+        .unwrap()
+}
 
-    // Finish layers
+#[actix_rt::main]
+async fn main() -> Result<()> {
+    // Setup tracing layers
     #[cfg(feature = "telemetry")]
-    let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+    let telemetry = tracing_opentelemetry::layer().with_tracer(init_tracer().await);
     let logger = tracing_subscriber::fmt::layer().json();
-
     let env_filter = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new("info"))
         .unwrap();
 
-    // Register all subscribers
+    // Decide on layers
     #[cfg(feature = "telemetry")]
     let collector = Registry::default().with(telemetry).with(logger).with(env_filter);
     #[cfg(not(feature = "telemetry"))]
     let collector = Registry::default().with(logger).with(env_filter);
 
+    // Initialize tracing
     tracing::subscriber::set_global_default(collector).unwrap();
 
     // Start kubernetes controller
@@ -87,7 +87,7 @@ async fn main() -> Result<()> {
     })
     .bind("0.0.0.0:8080")
     .expect("Can not bind to 0.0.0.0:8080")
-    .shutdown_timeout(0);
+    .shutdown_timeout(5);
 
     tokio::select! {
         _ = drainer => warn!("controller drained"),

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -12,3 +12,27 @@ pub fn get_trace_id() -> String {
         .trace_id()
         .to_hex()
 }
+
+#[cfg(feature = "telemetry")]
+pub async fn init_tracer() -> opentelemetry::sdk::trace::Tracer {
+    let otlp_endpoint =
+        std::env::var("OPENTELEMETRY_ENDPOINT_URL").expect("Need a otel tracing collector configured");
+
+    let channel = tonic::transport::Channel::from_shared(otlp_endpoint)
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+
+    opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(opentelemetry_otlp::new_exporter().tonic().with_channel(channel))
+        .with_trace_config(opentelemetry::sdk::trace::config().with_resource(
+            opentelemetry::sdk::Resource::new(vec![opentelemetry::KeyValue::new(
+                "service.name",
+                "foo-controller",
+            )]),
+        ))
+        .install_batch(opentelemetry::runtime::Tokio)
+        .unwrap()
+}


### PR DESCRIPTION
always a bunch of annoying things every upgrade here:

- need explicit tonic dep now just to configure the [channel/endpoint](https://docs.rs/tonic/0.5.0/tonic/transport/channel/struct.Channel.html)
- need to await a connection ourselves... (see [raw tonic interface](https://docs.rs/tonic/0.5.2/tonic/transport/index.html))

on the plus side it does seem to work