### PR TITLE
Avoid `sudo chown` for `tilt up`

### DIFF
--- a/justfile
+++ b/justfile
@@ -29,8 +29,7 @@ compile:
     -t clux/muslrust:stable \
     cargo build --release --bin controller
   # TODO: re-enable --features=telemetry
-  sudo chown $USER:$USER -R target
-  mv target/x86_64-unknown-linux-musl/release/controller .
+  cp target/x86_64-unknown-linux-musl/release/controller .
 
 # docker build (requires compile step first)
 build:


### PR DESCRIPTION
`tilt up` is great, but `compile` gets stuck at `sudo chown`.

I think copying instead of moving is fine (18MB).