### PR TITLE
Feat: add finalizer usage on the new crd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Kube Api Error: {0}")]
-    KubeError(#[source] kube::Error),
+    KubeError(#[source] kube::runtime::finalizer::Error<kube::Error>),
 
     #[error("SerializationError: {0}")]
     SerializationError(#[source] serde_json::Error),


### PR DESCRIPTION
Fix: https://github.com/kube-rs/controller-rs/issues/24

> Hi, I just recently learned the rust language and really like your projects, thank you for reviewing

This PR add finalizer for the new CRD:

1. when the CR `Document` been created, the controller will add a finalizer `finalizer.document.io`.
2. when delete the CR, the controller will record an event with delete infromation , and remove the finalizer