### PR TITLE
Factor `Metrics` out into its own file and use `Drop` for measurement

### DIFF
--- a/justfile
+++ b/justfile
@@ -19,6 +19,10 @@ run-telemetry:
 run:
   RUST_LOG=info,kube=debug,controller=debug cargo run
 
+# format with nightly rustfmt
+fmt:
+  cargo +nightly fmt
+
 # compile for musl (for docker image)
 compile features="":
   #!/usr/bin/env bash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,12 @@ pub enum Error {
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+impl Error {
+    pub fn metric_label(&self) -> String {
+        format!("{}", self).to_lowercase()
+    }
+}
+
 /// State machinery for kube, as exposeable to actix
 pub mod manager;
 pub use manager::Manager;
@@ -19,3 +25,7 @@ pub use manager::Document;
 
 /// Log and trace integrations
 pub mod telemetry;
+
+/// Metrics
+mod metrics;
+pub use metrics::Metrics;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,17 +2,25 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Finalizer Error: {0}")]
-    FinalizerError(#[source] kube::runtime::finalizer::Error<kube::Error>),
-
     #[error("SerializationError: {0}")]
     SerializationError(#[source] serde_json::Error),
+
+    #[error("Kube Error: {0}")]
+    KubeError(#[source] kube::Error),
+
+    #[error("Finalizer Error: {0}")]
+    // NB: awkward type because finalizer::Error embeds the reconciler error (which is this)
+    // so boxing this error to break cycles
+    FinalizerError(#[source] Box<kube::runtime::finalizer::Error<Error>>),
+
+    #[error("IllegalDocument")]
+    IllegalDocument,
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 impl Error {
     pub fn metric_label(&self) -> String {
-        format!("{}", self).to_lowercase()
+        format!("{:?}", self).to_lowercase()
     }
 }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,4 +1,4 @@
-use crate::{telemetry, Metrics, Error, Result};
+use crate::{telemetry, Error, Metrics, Result};
 use chrono::{DateTime, Utc};
 use futures::{future::BoxFuture, FutureExt, StreamExt};
 use kube::{

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,4 +1,4 @@
-use crate::{telemetry, Error, Result};
+use crate::{telemetry, Metrics, Error, Result};
 use chrono::{DateTime, Utc};
 use futures::{future::BoxFuture, FutureExt, StreamExt};
 use kube::{
@@ -11,18 +11,11 @@ use kube::{
     },
     CustomResource, Resource,
 };
-use prometheus::{
-    default_registry, proto::MetricFamily, register_histogram_vec, register_int_counter, HistogramVec,
-    IntCounter,
-};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
-use tokio::{
-    sync::RwLock,
-    time::{Duration, Instant},
-};
+use tokio::{sync::RwLock, time::Duration};
 use tracing::*;
 
 static DOCUMENT_FINALIZER: &str = "documents.kube.rs";
@@ -38,7 +31,6 @@ pub struct DocumentSpec {
     hide: bool,
     content: String,
 }
-
 /// The status object of `Document`
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct DocumentStatus {
@@ -66,34 +58,24 @@ struct Context {
 async fn reconcile(doc: Arc<Document>, ctx: Arc<Context>) -> Result<Action> {
     let trace_id = telemetry::get_trace_id();
     Span::current().record("trace_id", &field::display(&trace_id));
-    let start = Instant::now();
-    ctx.metrics.reconciliations.inc();
-    let client = ctx.client.clone();
-    let name = doc.name_any();
-    let ns = doc.namespace().unwrap();
-    let docs: Api<Document> = Api::namespaced(client, &ns);
+    ctx.metrics.count_and_measure();
+    let ns = doc.namespace().unwrap(); // doc is namespace scoped
+    let docs: Api<Document> = Api::namespaced(ctx.client.clone(), &ns);
 
-    let action = finalizer(&docs, DOCUMENT_FINALIZER, doc, |event| async {
+    info!("Reconciling Document \"{}\" in {}", doc.name_any(), ns);
+    finalizer(&docs, DOCUMENT_FINALIZER, doc, |event| async {
         match event {
             Finalizer::Apply(doc) => doc.reconcile(ctx.clone()).await,
             Finalizer::Cleanup(doc) => doc.cleanup(ctx.clone()).await,
         }
     })
     .await
-    .map_err(Error::FinalizerError);
-
-    let duration = start.elapsed().as_millis() as f64 / 1000.0;
-    ctx.metrics
-        .reconcile_duration
-        .with_label_values(&[])
-        .observe(duration);
-    info!("Reconciled Document \"{}\" in {}", name, ns);
-    action
+    .map_err(Error::FinalizerError)
 }
 
-fn error_policy(_doc: Arc<Document>, error: &Error, ctx: Arc<Context>) -> Action {
+fn error_policy(doc: Arc<Document>, error: &Error, ctx: Arc<Context>) -> Action {
     warn!("reconcile failed: {:?}", error);
-    ctx.metrics.failures.inc();
+    ctx.metrics.reconcile_failure(&doc, error);
     Action::requeue(Duration::from_secs(5 * 60))
 }
 
@@ -157,36 +139,6 @@ impl Document {
     }
 }
 
-/// Prometheus Metrics to be exposed on /metrics
-#[derive(Clone)]
-pub struct Metrics {
-    pub reconciliations: IntCounter,
-    pub failures: IntCounter,
-    pub reconcile_duration: HistogramVec,
-}
-impl Metrics {
-    fn new() -> Self {
-        let reconcile_histogram = register_histogram_vec!(
-            "doc_controller_reconcile_duration_seconds",
-            "The duration of reconcile to complete in seconds",
-            &[],
-            vec![0.01, 0.1, 0.25, 0.5, 1., 5., 15., 60.]
-        )
-        .unwrap();
-
-        Metrics {
-            reconciliations: register_int_counter!("doc_controller_reconciliations_total", "reconciliations")
-                .unwrap(),
-            failures: register_int_counter!(
-                "doc_controller_reconciliation_errors_total",
-                "reconciliation errors"
-            )
-            .unwrap(),
-            reconcile_duration: reconcile_histogram,
-        }
-    }
-}
-
 /// Diagnostics to be exposed by the web server
 #[derive(Clone, Serialize)]
 pub struct Diagnostics {
@@ -195,8 +147,8 @@ pub struct Diagnostics {
     #[serde(skip)]
     pub reporter: Reporter,
 }
-impl Diagnostics {
-    fn new() -> Self {
+impl Default for Diagnostics {
+    fn default() -> Self {
         Self {
             last_event: Utc::now(),
             reporter: "doc-controller".into(),
@@ -205,7 +157,7 @@ impl Diagnostics {
 }
 
 /// Data owned by the Manager
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Manager {
     /// Diagnostics populated by the reconciler
     diagnostics: Arc<RwLock<Diagnostics>>,
@@ -219,12 +171,11 @@ impl Manager {
     /// It is up to `main` to wait for the controller stream.
     pub async fn new() -> (Self, BoxFuture<'static, ()>) {
         let client = Client::try_default().await.expect("create client");
-        let metrics = Metrics::new();
-        let diagnostics = Arc::new(RwLock::new(Diagnostics::new()));
+        let manager = Manager::default();
         let context = Arc::new(Context {
             client: client.clone(),
-            metrics: metrics.clone(),
-            diagnostics: diagnostics.clone(),
+            metrics: Metrics::default(),
+            diagnostics: manager.diagnostics.clone(),
         });
 
         let docs = Api::<Document>::all(client);
@@ -241,12 +192,12 @@ impl Manager {
             .for_each(|_| futures::future::ready(()))
             .boxed();
 
-        (Self { diagnostics }, controller)
+        (manager, controller)
     }
 
     /// Metrics getter
-    pub fn metrics(&self) -> Vec<MetricFamily> {
-        default_registry().gather()
+    pub fn metrics(&self) -> Vec<prometheus::proto::MetricFamily> {
+        prometheus::default_registry().gather()
     }
 
     /// State getter

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,9 @@
-use prometheus::{register_int_counter, register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounter, IntCounterVec};
+use crate::{Document, Error};
 use kube::ResourceExt;
-use crate::{Error, Document};
+use prometheus::{
+    register_histogram_vec, register_int_counter, register_int_counter_vec, HistogramVec, IntCounter,
+    IntCounterVec,
+};
 use tokio::time::Instant;
 
 #[derive(Clone)]
@@ -23,12 +26,14 @@ impl Metrics {
             "doc_controller_reconciliation_errors_total",
             "reconciliation errors",
             &["instance", "error"]
-        ).unwrap();
-        let reconciliations = register_int_counter!("doc_controller_reconciliations_total", "reconciliations").unwrap();
+        )
+        .unwrap();
+        let reconciliations =
+            register_int_counter!("doc_controller_reconciliations_total", "reconciliations").unwrap();
         Metrics {
             reconciliations,
             failures,
-            reconcile_duration
+            reconcile_duration,
         }
     }
 }
@@ -58,8 +63,6 @@ impl Drop for ReconcileMeasurer {
     fn drop(&mut self) {
         #[allow(clippy::cast_precision_loss)]
         let duration = self.start.elapsed().as_millis() as f64 / 1000.0;
-        self.metric
-            .with_label_values(&[])
-            .observe(duration);
+        self.metric.with_label_values(&[]).observe(duration);
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,65 @@
+use prometheus::{register_int_counter, register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounter, IntCounterVec};
+use kube::ResourceExt;
+use crate::{Error, Document};
+use tokio::time::Instant;
+
+#[derive(Clone)]
+pub struct Metrics {
+    pub reconciliations: IntCounter,
+    pub failures: IntCounterVec,
+    pub reconcile_duration: HistogramVec,
+}
+
+impl Metrics {
+    pub fn default() -> Self {
+        let reconcile_duration = register_histogram_vec!(
+            "doc_controller_reconcile_duration_seconds",
+            "The duration of reconcile to complete in seconds",
+            &[],
+            vec![0.01, 0.1, 0.25, 0.5, 1., 5., 15., 60.]
+        )
+        .unwrap();
+        let failures = register_int_counter_vec!(
+            "doc_controller_reconciliation_errors_total",
+            "reconciliation errors",
+            &["instance", "error"]
+        ).unwrap();
+        let reconciliations = register_int_counter!("doc_controller_reconciliations_total", "reconciliations").unwrap();
+        Metrics {
+            reconciliations,
+            failures,
+            reconcile_duration
+        }
+    }
+}
+
+impl Metrics {
+    pub fn reconcile_failure(&self, doc: &Document, e: &Error) {
+        self.failures
+            .with_label_values(&[doc.name_any().as_ref(), e.metric_label().as_ref()])
+            .inc()
+    }
+
+    pub fn count_and_measure(&self) -> ReconcileMeasurer {
+        self.reconciliations.inc();
+        ReconcileMeasurer {
+            start: Instant::now(),
+            metric: self.reconcile_duration.clone(),
+        }
+    }
+}
+
+pub struct ReconcileMeasurer {
+    start: Instant,
+    metric: HistogramVec,
+}
+
+impl Drop for ReconcileMeasurer {
+    fn drop(&mut self) {
+        #[allow(clippy::cast_precision_loss)]
+        let duration = self.start.elapsed().as_millis() as f64 / 1000.0;
+        self.metric
+            .with_label_values(&[])
+            .observe(duration);
+    }
+}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -13,8 +13,8 @@ pub struct Metrics {
     pub reconcile_duration: HistogramVec,
 }
 
-impl Metrics {
-    pub fn default() -> Self {
+impl Default for Metrics {
+    fn default() -> Self {
         let reconcile_duration = register_histogram_vec!(
             "doc_controller_reconcile_duration_seconds",
             "The duration of reconcile to complete in seconds",

--- a/yaml/instance-illegal.yaml
+++ b/yaml/instance-illegal.yaml
@@ -1,0 +1,9 @@
+apiVersion: kube.rs/v1
+kind: Document
+metadata:
+  name: illegal
+spec:
+  title: Breaking the law
+  hide: false
+  content: |
+    This document will cause the reconcile fn to return an Err which will be visible in the metrics of the controller.


### PR DESCRIPTION
This avoids crowding the reconciler with error-prone specifics that can be handled more cleanly in a separate module.