### PR TITLE
Update format of `.status` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ https://hub.docker.com/r/clux/controller/tags/)
 
 A rust kubernetes reference controller for a [`Document` resource](https://github.com/kube-rs/controller-rs/blob/master/yaml/crd.yaml) using [kube-rs](https://github.com/kube-rs/kube-rs/), with observability instrumentation.
 
-The `Controller` object reconciles `Document` instances when changes to it are detected, writes to its .status object, creates associated events, and uses finalizers for guaranteed delete handling.
+The `Controller` object reconciles `Document` instances when changes to it are detected, writes to its `.status` object, creates associated events, and uses finalizers for guaranteed delete handling.
 
 ## Requirements
 - A Kubernetes cluster / k3d instance
@@ -73,7 +73,7 @@ kubectl delete doc lorem
 kubectl edit doc lorem # change hidden
 ```
 
-The reconciler will run and write the status object on every change. You should see results in the logs of the pod, or on the .status object outputs of `kubectl get doc -oyaml`.
+The reconciler will run and write the status object on every change. You should see results in the logs of the pod, or on the `.status` object outputs of `kubectl get doc -oyaml`.
 
 ### Webapp output
 The sample web server exposes some example metrics and debug information you can inspect with `curl`.


### PR DESCRIPTION
Update .status to `.status`.
Signed-off-by: Ian Stanton <ian@coredb.io>