### PR TITLE
Add manual tests for valid TraceIds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,8 @@ jobs:
         run: cargo build
       - name: Run workspace unit tests
         run: cargo test
+      - name: Run full feature unit tests
+        run: cargo test --lib --all-features
       - name: Generate crd.yaml
         run: cargo run --bin crdgen > yaml/crd.yaml
       - name: Generate deployment.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,8 +224,6 @@ jobs:
         run: cargo build
       - name: Run workspace unit tests
         run: cargo test
-      - name: Run full feature unit tests
-        run: cargo test --lib --all-features
       - name: Generate crd.yaml
         run: cargo run --bin crdgen > yaml/crd.yaml
       - name: Generate deployment.yaml

--- a/justfile
+++ b/justfile
@@ -35,7 +35,7 @@ test-integration: install-crd
   cargo test -- --ignored
 # run telemetry tests
 test-telemetry:
-  OPENTELEMETRY_ENDPOINT_URL=https://0.0.0.0:55680 cargo test --lib --all-features -- --ignored
+  OPENTELEMETRY_ENDPOINT_URL=https://0.0.0.0:55680 cargo test --lib --all-features -- get_trace_id_returns_valid_traces --ignored
 
 # compile for musl (for docker image)
 compile features="":

--- a/justfile
+++ b/justfile
@@ -33,6 +33,9 @@ test-unit:
 # run integration tests
 test-integration: install-crd
   cargo test -- --ignored
+# run telemetry tests
+test-telemetry:
+  OPENTELEMETRY_ENDPOINT_URL=https://0.0.0.0:55680 cargo test --lib --all-features -- --ignored
 
 # compile for musl (for docker image)
 compile features="":

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -35,3 +35,16 @@ pub async fn init_tracer() -> opentelemetry::sdk::trace::Tracer {
         .install_batch(opentelemetry::runtime::Tokio)
         .unwrap()
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[cfg(feature = "telemetry")]
+    #[test]
+    fn get_trace_id_returns_valid_traces() {
+        let id = get_trace_id().to_bytes();
+        dbg!(id);
+        assert!(id.iter().any(|digit| *digit != 0), "valid trace");
+    }
+}

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,4 +1,5 @@
 use opentelemetry::trace::TraceId;
+use tracing_subscriber::{prelude::*, EnvFilter, Registry};
 
 ///  Fetch an opentelemetry::trace::TraceId as hex through the full tracing stack
 pub fn get_trace_id() -> TraceId {
@@ -13,7 +14,7 @@ pub fn get_trace_id() -> TraceId {
 }
 
 #[cfg(feature = "telemetry")]
-pub async fn init_tracer() -> opentelemetry::sdk::trace::Tracer {
+async fn init_tracer() -> opentelemetry::sdk::trace::Tracer {
     let otlp_endpoint =
         std::env::var("OPENTELEMETRY_ENDPOINT_URL").expect("Need a otel tracing collector configured");
 
@@ -36,15 +37,41 @@ pub async fn init_tracer() -> opentelemetry::sdk::trace::Tracer {
         .unwrap()
 }
 
+/// Initialize tracing
+pub async fn init() {
+    // Setup tracing layers
+    #[cfg(feature = "telemetry")]
+    let telemetry = tracing_opentelemetry::layer().with_tracer(init_tracer().await);
+    let logger = tracing_subscriber::fmt::layer();
+    let env_filter = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new("info"))
+        .unwrap();
+
+    // Decide on layers
+    #[cfg(feature = "telemetry")]
+    let collector = Registry::default().with(telemetry).with(logger).with(env_filter);
+    #[cfg(not(feature = "telemetry"))]
+    let collector = Registry::default().with(logger).with(env_filter);
+
+    // Initialize tracing
+    tracing::subscriber::set_global_default(collector).unwrap();
+}
+
 #[cfg(test)]
 mod test {
-    use super::*;
-
+    // This test only works when telemetry is initialized fully
+    // and requires OPENTELEMETRY_ENDPOINT_URL pointing to a valid server
+    // .. tonic does not seem to allow any mocks here
     #[cfg(feature = "telemetry")]
-    #[test]
-    fn get_trace_id_returns_valid_traces() {
-        let id = get_trace_id().to_bytes();
-        dbg!(id);
-        assert!(id.iter().any(|digit| *digit != 0), "valid trace");
+    #[tokio::test]
+    #[ignore = "requires a trace exporter"]
+    async fn get_trace_id_returns_valid_traces() {
+        use super::*;
+        super::init().await;
+        #[tracing::instrument(name = "test_span")] // need to be in an instrumented fn
+        fn test_trace_id() -> TraceId {
+            get_trace_id()
+        }
+        assert_ne!(test_trace_id(), TraceId::INVALID, "valid trace");
     }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -61,7 +61,6 @@ pub async fn init() {
 mod test {
     // This test only works when telemetry is initialized fully
     // and requires OPENTELEMETRY_ENDPOINT_URL pointing to a valid server
-    // .. tonic does not seem to allow any mocks here
     #[cfg(feature = "telemetry")]
     #[tokio::test]
     #[ignore = "requires a trace exporter"]


### PR DESCRIPTION
to avoid further confusion for stuff like #44. sets up a minimal context to verify that we get a trace.
saved under a shortcut for `just test-telemetry` that requires something like `just forward-tempo` to work.

can be made fully automated (see below), but it requires a valid tempo instance on CI or some mocking setup for tracers that does not produce invalid traceids (afaikt the mock tracers all produce zeroes).