### PR TITLE
Showcase predicate filters with timestamp in status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,8 @@ hyper = "0.14.23"
 tower-test = "0.4.0"
 
 [dependencies.kube]
-features = ["runtime", "client", "derive"]
-#version = "0.81.0"
+features = ["runtime", "client", "derive", "unstable-runtime"]
+version = "0.81.0"
 
 # testing new releases - ignore
 #git = "https://github.com/kube-rs/kube.git"

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -42,7 +42,7 @@ pub async fn init() {
     // Setup tracing layers
     #[cfg(feature = "telemetry")]
     let telemetry = tracing_opentelemetry::layer().with_tracer(init_tracer().await);
-    let logger = tracing_subscriber::fmt::layer();
+    let logger = tracing_subscriber::fmt::layer().compact();
     let env_filter = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new("info"))
         .unwrap();

--- a/yaml/crd.yaml
+++ b/yaml/crd.yaml
@@ -41,8 +41,11 @@ spec:
             properties:
               hidden:
                 type: boolean
+              last_update:
+                type: string
             required:
             - hidden
+            - last_update
             type: object
         required:
         - spec


### PR DESCRIPTION
This was impossible before kube 0.81.

Having a random timestamp in a status field would cause the controller to spin constantly as it kept triggering itself.
Now with predicates from https://github.com/kube-rs/kube/pull/911 it is possible to avoid this and have timestamps (say) in status objects.

Probably not going to merge this as these are unstable interfaces, just showcasing it here atm.