### PR TITLE
Network policy template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,10 +158,10 @@ jobs:
           path: /tmp
       - name: Load docker image from tarball
         run: docker load --input /tmp/image.tar
+      #apiPort="$(kubectl get svc kubernetes -n default -ojson | jq '.spec.ports[0].targetPort')"
       - run: |
-          apiPort="$(kubectl get svc kubernetes -n default -ojson | jq '.spec.ports[0].targetPort')"
-          echo $apiPort
           kubectl get svc kubernetes -n default -oyaml
+          apiPort=https
           helm template charts/doc-controller --set version=latest --set networkPolicy.kubernetesPort=${apiPort} | kubectl apply -f -
       - run: kubectl wait --for=condition=available deploy/doc-controller --timeout=30s
       - run: kubectl apply -f yaml/instance-samuel.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.26
+          version: v1.27
           k3d-name: kube
           k3d-args: "--no-lb --no-rollback --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
       - run: kubectl apply -f yaml/crd.yaml
@@ -158,11 +158,12 @@ jobs:
           path: /tmp
       - name: Load docker image from tarball
         run: docker load --input /tmp/image.tar
-      - run: helm template charts/doc-controller --set version="latest" | kubectl apply -f -
+      - run: helm template charts/doc-controller --set version=latest --set networkPolicy.kubernetesPort=443 | kubectl apply -f -
       - run: kubectl wait --for=condition=available deploy/doc-controller --timeout=30s
       - run: kubectl apply -f yaml/instance-samuel.yaml
       - run: sleep 2 # TODO: add condition on status and wait for it instead
       # verify reconcile actions have happened
+      - run: kubectl logs deploy/doc-controller
       - run: kubectl get event --field-selector "involvedObject.kind=Document,involvedObject.name=samuel" | grep "HideRequested"
       - run: kubectl get doc -oyaml | grep -A1 finalizers | grep documents.kube.rs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,8 @@ jobs:
           path: /tmp
       - name: Load docker image from tarball
         run: docker load --input /tmp/image.tar
-      - run: |
+      - name: helm template | kubctl apply
+        run: |
           apiserver="$(kubectl get endpoints kubernetes -ojson | jq '.subsets[0].addresses[0].ip' -r)"
           helm template charts/doc-controller \
             --set version=latest \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,8 @@ jobs:
         run: docker load --input /tmp/image.tar
       - run: |
           apiPort="$(kubectl get svc kubernetes -n default -ojson | jq '.spec.ports[0].targetPort')"
+          echo $apiPort
+          kubectl get svc kubernetes -n default -oyaml
           helm template charts/doc-controller --set version=latest --set networkPolicy.kubernetesPort=${apiPort} | kubectl apply -f -
       - run: kubectl wait --for=condition=available deploy/doc-controller --timeout=30s
       - run: kubectl apply -f yaml/instance-samuel.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,9 @@ jobs:
           path: /tmp
       - name: Load docker image from tarball
         run: docker load --input /tmp/image.tar
-      - run: helm template charts/doc-controller --set version=latest --set networkPolicy.kubernetesPort=443 | kubectl apply -f -
+      - run: |
+          apiPort="$(kubectl get svc kubernetes -n default -ojson | jq '.spec.ports[0].targetPort')"
+          helm template charts/doc-controller --set version=latest --set networkPolicy.kubernetesPort=${apiPort} | kubectl apply -f -
       - run: kubectl wait --for=condition=available deploy/doc-controller --timeout=30s
       - run: kubectl apply -f yaml/instance-samuel.yaml
       - run: sleep 2 # TODO: add condition on status and wait for it instead

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,11 +158,18 @@ jobs:
           path: /tmp
       - name: Load docker image from tarball
         run: docker load --input /tmp/image.tar
-      - run: helm template charts/doc-controller --set version=latest | kubectl apply -f -
+      - run: |
+          apiserver="$(kubectl get endpoints kubernetes -ojson | jq '.subsets[0].addresses[0].ip' -r)"
+          helm template charts/doc-controller \
+            --set version=latest \
+            --set networkPolicy.enabled=true \
+            --set networkPolicy.apiserver.0=${apiserver}/32 \
+            | kubectl apply -f -
       - run: kubectl wait --for=condition=available deploy/doc-controller --timeout=30s
       - run: kubectl apply -f yaml/instance-samuel.yaml
       - run: sleep 2 # TODO: add condition on status and wait for it instead
       # verify reconcile actions have happened
+      - run: kubectl get netpol doc-controller -oyaml
       - run: kubectl logs deploy/doc-controller
       - run: kubectl get event --field-selector "involvedObject.kind=Document,involvedObject.name=samuel" | grep "HideRequested"
       - run: kubectl get doc -oyaml | grep -A1 finalizers | grep documents.kube.rs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,6 @@ jobs:
           path: /tmp
       - name: Load docker image from tarball
         run: docker load --input /tmp/image.tar
-      #apiPort="$(kubectl get svc kubernetes -n default -ojson | jq '.spec.ports[0].targetPort')"
       - run: helm template charts/doc-controller --set version=latest | kubectl apply -f -
       - run: kubectl wait --for=condition=available deploy/doc-controller --timeout=30s
       - run: kubectl apply -f yaml/instance-samuel.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
       - run: |
           kubectl get svc kubernetes -n default -oyaml
           apiPort=https
-          helm template charts/doc-controller --set version=latest --set networkPolicy.kubernetesPort=${apiPort} | kubectl apply -f -
+          helm template charts/doc-controller --set version=latest --set networkPolicy.kubernetesPort=${apiPort} --set networkPolicy.enabled=false | kubectl apply -f -
       - run: kubectl wait --for=condition=available deploy/doc-controller --timeout=30s
       - run: kubectl apply -f yaml/instance-samuel.yaml
       - run: sleep 2 # TODO: add condition on status and wait for it instead

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,10 +159,7 @@ jobs:
       - name: Load docker image from tarball
         run: docker load --input /tmp/image.tar
       #apiPort="$(kubectl get svc kubernetes -n default -ojson | jq '.spec.ports[0].targetPort')"
-      - run: |
-          kubectl get svc kubernetes -n default -oyaml
-          apiPort=https
-          helm template charts/doc-controller --set version=latest --set networkPolicy.kubernetesPort=${apiPort} --set networkPolicy.enabled=false | kubectl apply -f -
+      - run: helm template charts/doc-controller --set version=latest | kubectl apply -f -
       - run: kubectl wait --for=condition=available deploy/doc-controller --timeout=30s
       - run: kubectl apply -f yaml/instance-samuel.yaml
       - run: sleep 2 # TODO: add condition on status and wait for it instead

--- a/charts/doc-controller/templates/deployment.yaml
+++ b/charts/doc-controller/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           value: {{ .Values.logging.env_filter }}
         {{- if .Values.tracing.enabled }}
         - name: OPENTELEMETRY_ENDPOINT_URL
-          value: {{ .Values.tracing.endpoint }}
+          value: https://{{ .Values.tracing.service }}.{{ .Values.tracing.namespace }}.cluster.local:{{ .Values.tracing.port }}
         {{- end }}
         {{- with .Values.env }}
         {{- toYaml . | nindent 8 }}

--- a/charts/doc-controller/templates/networkpolicy.yaml
+++ b/charts/doc-controller/templates/networkpolicy.yaml
@@ -28,14 +28,13 @@ spec:
 
   # Kubernetes apiserver access
   - to:
-    - namespaceSelector:
-        matchLabels:
-          name: default
+    - ipBlock:
+    {{- range .Values.networkPolicy.apiserver }}
+        cidr: {{ . }}
+    {{- end }}
     ports:
     - port: 443
-      protocol: TCP
     - port: 6443
-      protocol: TCP
 
   {{- if .Values.networkPolicy.dns }}
   # DNS egress

--- a/charts/doc-controller/templates/networkpolicy.yaml
+++ b/charts/doc-controller/templates/networkpolicy.yaml
@@ -7,31 +7,34 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "controller.labels" . | nindent 4 }}
-  {{- with .Values.service.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
+  podSelector:
+    matchLabels:
+      {{- include "controller.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
   egress:
   {{- if .Values.tracing.enabled }}
   # pushing tracing spans to a collector
   - to:
-    - ports:
-      - port: {{ .Values.tracing.collector.port }}
-        protocol: TCP
-      to:
     - namespaceSelector:
         matchLabels:
-          name: {{.Values.tracing.collector.namespace }}
+          name: {{.Values.tracing.namespace }}
+    ports:
+    - port: {{ .Values.tracing.port }}
+      protocol: TCP
   {{- end }}
 
   # Kubernetes apiserver access
   - to:
-    - ports:
-      - port: {{ .Values.networkPolicy.kubernetesPort }}
-        protocol: TCP
-    - namespaceSelector:
+    - podSelector: {}
+      namespaceSelector:
         matchLabels:
           name: default
+    ports:
+    - port: {{ .Values.networkPolicy.kubernetesPort }}
+      protocol: TCP
 
   {{- if .Values.networkPolicy.dns }}
   # DNS egress
@@ -39,9 +42,9 @@ spec:
     - podSelector:
         matchLabels:
           k8s-app: kube-dns
-      ports:
-      - port: 53
-        protocol: UDP
+    ports:
+    - port: 53
+      protocol: UDP
   {{- end }}
 
   ingress:
@@ -60,12 +63,5 @@ spec:
       protocol: TCP
   {{- end }}
   {{- end }}
-
-  podSelector:
-    matchLabels:
-      {{- include "controller.selectorLabels" . | nindent 6 }}
-  policyTypes:
-  - Ingress
-  - Egress
 
 {{- end }}

--- a/charts/doc-controller/templates/networkpolicy.yaml
+++ b/charts/doc-controller/templates/networkpolicy.yaml
@@ -34,7 +34,9 @@ spec:
     {{- end }}
     ports:
     - port: 443
+      protocol: TCP
     - port: 6443
+      protocol: TCP
 
   {{- if .Values.networkPolicy.dns }}
   # DNS egress

--- a/charts/doc-controller/templates/networkpolicy.yaml
+++ b/charts/doc-controller/templates/networkpolicy.yaml
@@ -28,8 +28,7 @@ spec:
 
   # Kubernetes apiserver access
   - to:
-    - podSelector: {}
-      namespaceSelector:
+    - namespaceSelector:
         matchLabels:
           name: default
     ports:

--- a/charts/doc-controller/templates/networkpolicy.yaml
+++ b/charts/doc-controller/templates/networkpolicy.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "controller.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "controller.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  egress:
+  {{- if .Values.tracing.enabled }}
+  # pushing tracing spans to a collector
+  - to:
+    - ports:
+      - port: {{ .Values.tracing.collector.port }}
+        protocol: TCP
+      to:
+    - namespaceSelector:
+        matchLabels:
+          name: {{.Values.tracing.collector.namespace }}
+  {{- end }}
+
+  # Kubernetes apiserver access
+  - to:
+    - ports:
+      - port: {{ .Values.networkPolicy.kubernetesPort }}
+        protocol: TCP
+    - namespaceSelector:
+        matchLabels:
+          name: default
+
+  {{- if .Values.networkPolicy.dns }}
+  # DNS egress
+  - to:
+    - podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+      ports:
+      - port: 53
+        protocol: UDP
+  {{- end }}
+
+  ingress:
+  {{- with .Values.networkPolicy.prometheus }}
+  {{- if .enabled }}
+  # prometheus metrics scraping support
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: {{ .namespace }}
+      podSelector:
+        matchLabels:
+          app: {{ .app }}
+    ports:
+    - port: {{ .port }}
+      protocol: TCP
+  {{- end }}
+  {{- end }}
+
+  podSelector:
+    matchLabels:
+      {{- include "controller.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+
+{{- end }}

--- a/charts/doc-controller/templates/networkpolicy.yaml
+++ b/charts/doc-controller/templates/networkpolicy.yaml
@@ -33,7 +33,9 @@ spec:
         matchLabels:
           name: default
     ports:
-    - port: {{ .Values.networkPolicy.kubernetesPort }}
+    - port: 443
+      protocol: TCP
+    - port: 6443
       protocol: TCP
 
   {{- if .Values.networkPolicy.dns }}

--- a/charts/doc-controller/templates/rbac.yaml
+++ b/charts/doc-controller/templates/rbac.yaml
@@ -24,7 +24,8 @@ metadata:
 rules:
   - apiGroups: ["kube.rs"]
     resources: ["documents", "documents/status", "documents/finalizers"]
-    verbs: ["get", "list", "watch", "patch", "update"]
+    #verbs: ["get", "list", "watch", "patch", "update", "delete"]
+    verbs: ["*"]
   - apiGroups: ["events.k8s.io"]
     resources: ["events"]
     verbs: ["create"]

--- a/charts/doc-controller/templates/rbac.yaml
+++ b/charts/doc-controller/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 ---
 # Scoped service account
 apiVersion: v1
@@ -12,6 +13,7 @@ metadata:
   {{- end }}
   namespace: {{ .Values.namespace }}
 automountServiceAccountToken: true
+{{- end }}
 
 ---
 # Access for the service account

--- a/charts/doc-controller/templates/rbac.yaml
+++ b/charts/doc-controller/templates/rbac.yaml
@@ -23,7 +23,7 @@ metadata:
   name: {{ include "controller.fullname" . }}
 rules:
   - apiGroups: ["kube.rs"]
-    resources: ["documents", "documents/status"]
+    resources: ["documents", "documents/status", "documents/finalizers"]
     verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["events.k8s.io"]
     resources: ["events"]

--- a/charts/doc-controller/templates/rbac.yaml
+++ b/charts/doc-controller/templates/rbac.yaml
@@ -24,7 +24,7 @@ metadata:
 rules:
   - apiGroups: ["kube.rs"]
     resources: ["documents", "documents/status", "documents/finalizers"]
-    verbs: ["get", "list", "watch", "patch"]
+    verbs: ["get", "list", "watch", "patch", "update"]
   - apiGroups: ["events.k8s.io"]
     resources: ["events"]
     verbs: ["create"]

--- a/charts/doc-controller/templates/rbac.yaml
+++ b/charts/doc-controller/templates/rbac.yaml
@@ -24,8 +24,7 @@ metadata:
 rules:
   - apiGroups: ["kube.rs"]
     resources: ["documents", "documents/status", "documents/finalizers"]
-    #verbs: ["get", "list", "watch", "patch", "update", "delete"]
-    verbs: ["*"]
+    verbs: ["get", "list", "watch", "patch", "update"]
   - apiGroups: ["events.k8s.io"]
     resources: ["events"]
     verbs: ["create"]

--- a/charts/doc-controller/templates/servicemonitor.yaml
+++ b/charts/doc-controller/templates/servicemonitor.yaml
@@ -34,7 +34,7 @@ spec:
   jobLabel: {{ include "controller.fullname" . }}
   selector:
     matchLabels:
-      app: {{ include "controller.fullname" . }}
+      {{- include "controller.selectorLabels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
       - {{ .Values.namespace }}

--- a/charts/doc-controller/values.yaml
+++ b/charts/doc-controller/values.yaml
@@ -38,10 +38,9 @@ tracing:
 networkPolicy:
   enabled: true
   dns: true
-  # How to reach the apiserver
-  # Takes addresses from "kubectl get endpoints kubernetes -n default"
+  # apiserver access: please scope; take addresses from "kubectl get endpoints kubernetes -n default"
   apiserver:
-  - "10.0.0.0/24" # Wide-open default
+  - "0.0.0.0/0" # extremely wide-open egress on ports 443 + 6443
   prometheus:
     enabled: true
     namespace: monitoring

--- a/charts/doc-controller/values.yaml
+++ b/charts/doc-controller/values.yaml
@@ -23,10 +23,26 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# Enable the feature-flagged opentelemetry trace layer pushing over grpc
+# Configure the gRPC opentelemetry push url
 tracing:
-  enabled: false # prefixes tag with otel
-  endpoint: "https://promstack-tempo.monitoring.svc.cluster.local:4317"
+  # Use the telemetry built image and inject OPENTELEMETRY_ENDPOINT_URL
+  enabled: false
+  # namespace of the collector
+  namespace: monitoring
+  # collector service name
+  service: promstack-tempo
+  # collector port for OTLP gRPC
+  port: 4317
+
+networkPolicy:
+  enabled: true
+  kubernetesPort: 443
+  dns: true
+  prometheus:
+    enabled: true
+    namespace: monitoring
+    app: prometheus
+    port: http
 
 logging:
   env_filter: info,kube=debug,controller=debug

--- a/charts/doc-controller/values.yaml
+++ b/charts/doc-controller/values.yaml
@@ -10,6 +10,7 @@ image:
 imagePullSecrets: []
 
 serviceAccount:
+  create: true
   annotations: {}
 podAnnotations: {}
 

--- a/charts/doc-controller/values.yaml
+++ b/charts/doc-controller/values.yaml
@@ -38,6 +38,10 @@ tracing:
 networkPolicy:
   enabled: true
   dns: true
+  # How to reach the apiserver
+  # Takes addresses from "kubectl get endpoints kubernetes -n default"
+  apiserver:
+  - "10.0.0.0/24" # Wide-open default
   prometheus:
     enabled: true
     namespace: monitoring

--- a/charts/doc-controller/values.yaml
+++ b/charts/doc-controller/values.yaml
@@ -37,7 +37,6 @@ tracing:
 
 networkPolicy:
   enabled: true
-  kubernetesPort: 6443
   dns: true
   prometheus:
     enabled: true

--- a/charts/doc-controller/values.yaml
+++ b/charts/doc-controller/values.yaml
@@ -36,7 +36,7 @@ tracing:
 
 networkPolicy:
   enabled: true
-  kubernetesPort: 443
+  kubernetesPort: 6443
   dns: true
   prometheus:
     enabled: true

--- a/yaml/deployment.yaml
+++ b/yaml/deployment.yaml
@@ -10,24 +10,31 @@ metadata:
     app.kubernetes.io/name: doc-controller
     app.kubernetes.io/version: "0.12.10"
 spec:
+  podSelector:
+    matchLabels:
+      app: doc-controller
+  policyTypes:
+  - Ingress
+  - Egress
   egress:
 
   # Kubernetes apiserver access
   - to:
-    - ports:
-      - port: 443
-        protocol: TCP
-    - namespaceSelector:
+    - podSelector: {}
+      namespaceSelector:
         matchLabels:
           name: default
+    ports:
+    - port: 6443
+      protocol: TCP
   # DNS egress
   - to:
     - podSelector:
         matchLabels:
           k8s-app: kube-dns
-      ports:
-      - port: 53
-        protocol: UDP
+    ports:
+    - port: 53
+      protocol: UDP
 
   ingress:
   # prometheus metrics scraping support
@@ -41,13 +48,6 @@ spec:
     ports:
     - port: http
       protocol: TCP
-
-  podSelector:
-    matchLabels:
-      app: doc-controller
-  policyTypes:
-  - Ingress
-  - Egress
 ---
 # Source: doc-controller/templates/rbac.yaml
 # Scoped service account

--- a/yaml/deployment.yaml
+++ b/yaml/deployment.yaml
@@ -20,14 +20,11 @@ spec:
 
   # Kubernetes apiserver access
   - to:
-    - namespaceSelector:
-        matchLabels:
-          name: default
+    - ipBlock:
+        cidr: 10.0.0.0/24
     ports:
     - port: 443
-      protocol: TCP
     - port: 6443
-      protocol: TCP
   # DNS egress
   - to:
     - podSelector:
@@ -72,7 +69,8 @@ metadata:
 rules:
   - apiGroups: ["kube.rs"]
     resources: ["documents", "documents/status", "documents/finalizers"]
-    verbs: ["get", "list", "watch", "patch", "update"]
+    #verbs: ["get", "list", "watch", "patch", "update", "delete"]
+    verbs: ["*"]
   - apiGroups: ["events.k8s.io"]
     resources: ["events"]
     verbs: ["create"]

--- a/yaml/deployment.yaml
+++ b/yaml/deployment.yaml
@@ -58,7 +58,7 @@ metadata:
   name: doc-controller
 rules:
   - apiGroups: ["kube.rs"]
-    resources: ["documents", "documents/status"]
+    resources: ["documents", "documents/status", "documents/finalizers"]
     verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["events.k8s.io"]
     resources: ["events"]

--- a/yaml/deployment.yaml
+++ b/yaml/deployment.yaml
@@ -21,7 +21,7 @@ spec:
   # Kubernetes apiserver access
   - to:
     - ipBlock:
-        cidr: 10.0.0.0/24
+        cidr: 0.0.0.0/0
     ports:
     - port: 443
       protocol: TCP

--- a/yaml/deployment.yaml
+++ b/yaml/deployment.yaml
@@ -1,4 +1,54 @@
 ---
+# Source: doc-controller/templates/networkpolicy.yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: doc-controller
+  namespace: default
+  labels:
+    app: doc-controller
+    app.kubernetes.io/name: doc-controller
+    app.kubernetes.io/version: "0.12.10"
+spec:
+  egress:
+
+  # Kubernetes apiserver access
+  - to:
+    - ports:
+      - port: 443
+        protocol: TCP
+    - namespaceSelector:
+        matchLabels:
+          name: default
+  # DNS egress
+  - to:
+    - podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+      ports:
+      - port: 53
+        protocol: UDP
+
+  ingress:
+  # prometheus metrics scraping support
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+      podSelector:
+        matchLabels:
+          app: prometheus
+    ports:
+    - port: http
+      protocol: TCP
+
+  podSelector:
+    matchLabels:
+      app: doc-controller
+  policyTypes:
+  - Ingress
+  - Egress
+---
 # Source: doc-controller/templates/rbac.yaml
 # Scoped service account
 apiVersion: v1

--- a/yaml/deployment.yaml
+++ b/yaml/deployment.yaml
@@ -71,8 +71,7 @@ metadata:
 rules:
   - apiGroups: ["kube.rs"]
     resources: ["documents", "documents/status", "documents/finalizers"]
-    #verbs: ["get", "list", "watch", "patch", "update", "delete"]
-    verbs: ["*"]
+    verbs: ["get", "list", "watch", "patch", "update"]
   - apiGroups: ["events.k8s.io"]
     resources: ["events"]
     verbs: ["create"]

--- a/yaml/deployment.yaml
+++ b/yaml/deployment.yaml
@@ -51,6 +51,19 @@ spec:
       protocol: TCP
 ---
 # Source: doc-controller/templates/rbac.yaml
+# Scoped service account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: doc-controller
+  labels:
+    app: doc-controller
+    app.kubernetes.io/name: doc-controller
+    app.kubernetes.io/version: "0.12.10"
+  namespace: default
+automountServiceAccountToken: true
+---
+# Source: doc-controller/templates/rbac.yaml
 # Access for the service account
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/yaml/deployment.yaml
+++ b/yaml/deployment.yaml
@@ -24,7 +24,9 @@ spec:
         cidr: 10.0.0.0/24
     ports:
     - port: 443
+      protocol: TCP
     - port: 6443
+      protocol: TCP
   # DNS egress
   - to:
     - podSelector:

--- a/yaml/deployment.yaml
+++ b/yaml/deployment.yaml
@@ -59,7 +59,7 @@ metadata:
 rules:
   - apiGroups: ["kube.rs"]
     resources: ["documents", "documents/status", "documents/finalizers"]
-    verbs: ["get", "list", "watch", "patch"]
+    verbs: ["get", "list", "watch", "patch", "update"]
   - apiGroups: ["events.k8s.io"]
     resources: ["events"]
     verbs: ["create"]

--- a/yaml/deployment.yaml
+++ b/yaml/deployment.yaml
@@ -20,11 +20,12 @@ spec:
 
   # Kubernetes apiserver access
   - to:
-    - podSelector: {}
-      namespaceSelector:
+    - namespaceSelector:
         matchLabels:
           name: default
     ports:
+    - port: 443
+      protocol: TCP
     - port: 6443
       protocol: TCP
   # DNS egress
@@ -48,19 +49,6 @@ spec:
     ports:
     - port: http
       protocol: TCP
----
-# Source: doc-controller/templates/rbac.yaml
-# Scoped service account
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: doc-controller
-  labels:
-    app: doc-controller
-    app.kubernetes.io/name: doc-controller
-    app.kubernetes.io/version: "0.12.10"
-  namespace: default
-automountServiceAccountToken: true
 ---
 # Source: doc-controller/templates/rbac.yaml
 # Access for the service account


### PR DESCRIPTION
Hardest part of this was actually the apiserver access egress...

I started out with:

```
    - namespaceSelector:
        matchLabels:
          name: default
```

which works in many places, but not all, so now we have this complicated endpoint query, that's fed into helm:

```sh
          apiserver="$(kubectl get endpoints kubernetes -ojson | jq '.subsets[0].addresses[0].ip' -r)"
          helm template charts/doc-controller \
            --set version=latest \
            --set networkPolicy.enabled=true \
            --set networkPolicy.apiserver.0=${apiserver}/32
```

which is fine, but we don't want first-comers to have to deal with all of that garbage so in `values.yaml` there's a wide-open egress default for where the endpoint is:

```yaml
networkPolicy
  apiserver:
  - "10.0.0.0/24" # Wide-open default
```

hopefully, that is a decent enough starting point that doesn't discourage networkpolicies, but also doesn't front-load all the mysticism..