### PR TITLE
ARM verify for clux/muslrust#134

### DIFF
--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ compile features="":
     -v cargo-cache:/root/.cargo \
     -v $PWD:/volume \
     -w /volume \
-    -t clux/muslrust:stable \
+    -t clux/muslrust:1.78.0-nightly-2024-02-26 \
     cargo build --release --features={{features}} --bin controller
   cp target/x86_64-unknown-linux-musl/release/controller .
 


### PR DESCRIPTION
i was expecting this part to work now, the tag chosen has arm

however it fails in the container with:

```
just compile
qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
cp: target/x86_64-unknown-linux-musl/release/controller: No such file or directory
```