### PR TITLE
upgrade to 0.90 and use body-collect helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "736f15a50e749d033164c56c09783b6102c4ff8da79ad77dbddbbaea0f8567f7"
 dependencies = [
  "futures-util",
  "http 1.1.0",
@@ -1205,7 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.89.0"
+version = "0.90.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bfada4e00dac93a7b94e454ae4cde04ff8786645ac1b98f31352272e2682b5"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1216,7 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.89.0"
+version = "0.90.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0708306b5c0085f249f5e3d2d56a9bbfe0cbbf4fd4eb9ed4bbba542ba7649a7"
 dependencies = [
  "base64 0.22.0",
  "bytes",
@@ -1235,7 +1239,6 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem",
- "pin-project",
  "rustls",
  "rustls-pemfile",
  "secrecy",
@@ -1252,14 +1255,15 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.89.0"
+version = "0.90.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7845bcc3e0f422df4d9049570baedd9bc1942f0504594e393e72fe24092559cf"
 dependencies = [
  "chrono",
  "form_urlencoded",
  "http 1.1.0",
  "json-patch",
  "k8s-openapi",
- "once_cell",
  "schemars",
  "serde",
  "serde_json",
@@ -1268,7 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.89.0"
+version = "0.90.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0d2527a6ff7adf00b34d558c4c5de9404abe28808cb0a4c64b57e2c1b0716a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1279,7 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.89.0"
+version = "0.90.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4560e2c5c71366f6dceb6500ce33cf72299aede92381bb875dc2d4ba4f102c21"
 dependencies = [
  "ahash",
  "async-trait",
@@ -1886,11 +1894,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+checksum = "8c4d6d8ad9f2492485e13453acbb291dd08f64441b6609c491f1c2cd2c6b4fe1"
 dependencies = [
  "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
@@ -2335,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,7 +496,6 @@ dependencies = [
  "chrono",
  "futures",
  "http 1.1.0",
- "http-body-util",
  "hyper 1.2.0",
  "k8s-openapi",
  "kube",
@@ -1207,8 +1206,6 @@ dependencies = [
 [[package]]
 name = "kube"
 version = "0.89.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92cd10d00ad38b2f72a5223cd8f2827968466a5d32ae89672d2b0df06488c499"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1220,8 +1217,6 @@ dependencies = [
 [[package]]
 name = "kube-client"
 version = "0.89.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b4ee4e409c9afb4e38a30802875acb108902387a41346bbc2fd8610df5f729"
 dependencies = [
  "base64 0.22.0",
  "bytes",
@@ -1258,8 +1253,6 @@ dependencies = [
 [[package]]
 name = "kube-core"
 version = "0.89.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beab9186726ed0c2420ff8a37b02f26dc62b3c33330ac60d0cc7605e1a6f6678"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1276,8 +1269,6 @@ dependencies = [
 [[package]]
 name = "kube-derive"
 version = "0.89.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b62b967344f8b961583480e4173b7c55bd448c700c71b0b780abbfc2dcda31"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1289,8 +1280,6 @@ dependencies = [
 [[package]]
 name = "kube-runtime"
 version = "0.89.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f0c0463270c844ff08e8a674777289afdb4cc6063036bed5dc35107f135808"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ features = ["runtime", "client", "derive" ]
 #version = "0.89.0"
 
 # testing new releases - ignore
-#git = "https://github.com/kube-rs/kube.git"
-#branch = "main"
+git = "https://github.com/kube-rs/kube.git"
+branch = "main"
 #rev = "19b90ad3a4dbc83e1dd742847c7707333259b1bb"
-path = "../kube/kube"
+#path = "../kube/kube"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,16 +48,15 @@ anyhow = "1.0.75"
 [dev-dependencies]
 assert-json-diff = "2.0.2"
 http = "1"
-http-body-util = "0.1.1"
 hyper = "1"
 tower-test = "0.4.0"
 
 [dependencies.kube]
 features = ["runtime", "client", "derive" ]
-version = "0.89.0"
+#version = "0.89.0"
 
 # testing new releases - ignore
 #git = "https://github.com/kube-rs/kube.git"
 #branch = "main"
 #rev = "19b90ad3a4dbc83e1dd742847c7707333259b1bb"
-#path = "../kube/kube"
+path = "../kube/kube"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,10 +53,10 @@ tower-test = "0.4.0"
 
 [dependencies.kube]
 features = ["runtime", "client", "derive" ]
-#version = "0.89.0"
+version = "0.90.0"
 
 # testing new releases - ignore
-git = "https://github.com/kube-rs/kube.git"
-branch = "main"
+#git = "https://github.com/kube-rs/kube.git"
+#branch = "main"
 #rev = "19b90ad3a4dbc83e1dd742847c7707333259b1bb"
 #path = "../kube/kube"

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -153,7 +153,7 @@ impl ApiServerVerifier {
             { "op": "test", "path": "/metadata/finalizers/0", "value": DOCUMENT_FINALIZER },
             { "op": "remove", "path": "/metadata/finalizers/0", "path": "/metadata/finalizers/0" }
         ]);
-        let req_body = request.into_body().collect().await.unwrap().to_bytes();
+        let req_body = request.into_body().collect_bytes().await?;
         let runtime_patch: serde_json::Value =
             serde_json::from_slice(&req_body).expect("valid document from runtime");
         assert_json_include!(actual: runtime_patch, expected: expected_patch);

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -128,7 +128,7 @@ impl ApiServerVerifier {
             { "op": "test", "path": "/metadata/finalizers", "value": null },
             { "op": "add", "path": "/metadata/finalizers", "value": vec![DOCUMENT_FINALIZER] }
         ]);
-        let req_body = request.into_body().collect().await.unwrap().to_bytes();
+        let req_body = request.into_body().collect_bytes().await.unwrap();
         let runtime_patch: serde_json::Value =
             serde_json::from_slice(&req_body).expect("valid document from runtime");
         assert_json_include!(actual: runtime_patch, expected: expected_patch);
@@ -153,7 +153,7 @@ impl ApiServerVerifier {
             { "op": "test", "path": "/metadata/finalizers/0", "value": DOCUMENT_FINALIZER },
             { "op": "remove", "path": "/metadata/finalizers/0", "path": "/metadata/finalizers/0" }
         ]);
-        let req_body = request.into_body().collect_bytes().await?;
+        let req_body = request.into_body().collect_bytes().await.unwrap();
         let runtime_patch: serde_json::Value =
             serde_json::from_slice(&req_body).expect("valid document from runtime");
         assert_json_include!(actual: runtime_patch, expected: expected_patch);
@@ -171,7 +171,7 @@ impl ApiServerVerifier {
             format!("/apis/events.k8s.io/v1/namespaces/default/events?")
         );
         // verify the event reason matches the expected
-        let req_body = request.into_body().collect().await.unwrap().to_bytes();
+        let req_body = request.into_body().collect_bytes().await.unwrap();
         let postdata: serde_json::Value =
             serde_json::from_slice(&req_body).expect("valid event from runtime");
         dbg!("postdata for event: {}", postdata.clone());
@@ -194,7 +194,7 @@ impl ApiServerVerifier {
                 doc.name_any()
             )
         );
-        let req_body = request.into_body().collect().await.unwrap().to_bytes();
+        let req_body = request.into_body().collect_bytes().await.unwrap();
         let json: serde_json::Value = serde_json::from_slice(&req_body).expect("patch_status object is json");
         let status_json = json.get("status").expect("status object").clone();
         let status: DocumentStatus = serde_json::from_value(status_json).expect("valid status");

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -2,7 +2,6 @@
 use crate::{Context, Document, DocumentSpec, DocumentStatus, Metrics, Result, DOCUMENT_FINALIZER};
 use assert_json_diff::assert_json_include;
 use http::{Request, Response};
-use http_body_util::BodyExt;
 use kube::{client::Body, Client, Resource, ResourceExt};
 use prometheus::Registry;
 use std::sync::Arc;


### PR DESCRIPTION
so that people can do https://github.com/kube-rs/controller-rs/blob/8bcd4b2a758178fe1a89580bcb0e05fb540e6e61/src/fixtures.rs#L131 without importing `http-body-util` (a new crate from most people POV)
