### PR TITLE
Try out `measured` for metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,9 +521,10 @@ dependencies = [
  "hyper 1.3.1",
  "k8s-openapi",
  "kube",
+ "lasso",
+ "measured",
  "opentelemetry",
  "opentelemetry-otlp",
- "prometheus",
  "schemars",
  "serde",
  "serde_json",
@@ -646,6 +647,19 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.60",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -907,6 +921,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -914,6 +937,12 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1360,6 +1389,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
+name = "lasso"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4644821e1c3d7a560fe13d842d13f587c07348a1a05d3a797152d41c90c56df2"
+dependencies = [
+ "dashmap",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1457,36 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "measured"
+version = "0.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "652bc741286361c06de8cb4d89b21a6437f120c508c51713663589eeb9928ac5"
+dependencies = [
+ "bytes",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "itoa",
+ "lasso",
+ "measured-derive",
+ "memchr",
+ "parking_lot",
+ "rustc-hash",
+ "ryu",
+]
+
+[[package]]
+name = "measured-derive"
+version = "0.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea497f33e1e856a376c32ad916f69a0bd3c597db1f912a399f842b01a4a685d"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
 
 [[package]]
 name = "memchr"
@@ -1777,21 +1846,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot",
- "protobuf",
- "thiserror",
-]
-
-[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,12 +1867,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"
@@ -1932,6 +1980,12 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ schemars = { version = "0.8.12", features = ["chrono"] }
 serde = { version = "1.0.185", features = ["derive"] }
 serde_json = "1.0.105"
 serde_yaml = "0.9.25"
-prometheus = "0.13.3"
 chrono = { version = "0.4.26", features = ["serde"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
@@ -44,6 +43,8 @@ opentelemetry-otlp = { version = "0.13.0", features = ["tokio"], optional = true
 tonic = { version = "0.9", optional = true }
 thiserror = "1.0.47"
 anyhow = "1.0.75"
+measured = { version = "0.0.21", features = ["lasso"] }
+lasso = "0.7.2"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -1,9 +1,8 @@
 //! Helper methods only available for tests
-use crate::{Context, Document, DocumentSpec, DocumentStatus, Metrics, Result, DOCUMENT_FINALIZER};
+use crate::{Context, Document, DocumentSpec, DocumentStatus, Result, DOCUMENT_FINALIZER};
 use assert_json_diff::assert_json_include;
 use http::{Request, Response};
 use kube::{client::Body, Client, Resource, ResourceExt};
-use prometheus::Registry;
 use std::sync::Arc;
 
 impl Document {
@@ -208,15 +207,14 @@ impl ApiServerVerifier {
 
 impl Context {
     // Create a test context with a mocked kube client, locally registered metrics and default diagnostics
-    pub fn test() -> (Arc<Self>, ApiServerVerifier, Registry) {
+    pub fn test() -> (Arc<Self>, ApiServerVerifier) {
         let (mock_service, handle) = tower_test::mock::pair::<Request<Body>, Response<Body>>();
         let mock_client = Client::new(mock_service, "default");
-        let registry = Registry::default();
         let ctx = Self {
             client: mock_client,
-            metrics: Metrics::default().register(&registry).unwrap(),
+            metrics: Arc::default(),
             diagnostics: Arc::default(),
         };
-        (Arc::new(ctx), ApiServerVerifier(handle), registry)
+        (Arc::new(ctx), ApiServerVerifier(handle))
     }
 }


### PR DESCRIPTION
A working POC for [conradludgate/measured](https://github.com/conradludgate/measured) ripping out [tikv/rust-prometheus](https://github.com/tikv/rust-prometheus). It did take me about 3h of cranking to make everything work like before, but it's a one time cost.

PROS:
- great [crate docs](https://docs.rs/measured/latest/measured/) with a specialised [docs chapter](https://docs.rs/measured/latest/measured/docs/index.html) with guides/getting started/examples
- nice type safe api around labels, i.e. [`CounterVec`](https://docs.rs/measured/latest/measured/type.CounterVec.html)
- best performer on cpu/memory performance - going by [upstream benchmarks](https://github.com/conradludgate/measured?tab=readme-ov-file#benchmark-results)
- benchmarks [against the major metrics crates](https://github.com/conradludgate/measured/blob/3722b59d9cc5603b2312f23a8ff17053d04fb086/core/Cargo.toml#L41C1-L41C11) in [benches](https://github.com/conradludgate/measured/tree/main/core/benches)
- by someone i trust to write good code, and has a chance of being maintained (tikv one is __kind of__ maintenaned)
- [Histogram Timers](https://docs.rs/measured/latest/measured/metric/struct.MetricVec.html#method.start_timer) out-of-the-box (could rip out our old ad-hoc `ReconcileMeasurer` scope thing)
- metric groups allow namespace prefixing groups of metrics ala [neon metrics](https://github.com/neondatabase/neon/blob/219e78f885486698a67da6ad62ef9f6d001b118a/proxy/src/http/health_server.rs#L60-L68)
- supports locking down cardinality with [FixedCardinality](https://docs.rs/measured/latest/measured/derive.FixedCardinalityLabel.html)
- can force it do take defaults everywhere to make [DynamicLabels](https://docs.rs/measured/latest/measured/label/trait.DynamicLabelSet.html) reasonably ergonomic

Note that the fixed cardinality stuff is not something we actually use, nor a main focus atm, as a controller benefits from dynamic labels for the objects it is reconciling and they are generally bound the cluster size anyway. But I can see it being useful for constraining error sizes down the road (the current error_label thing is very lazy and could blow up a bit under bad conditions).

CONS:
- complexity overhead for dealing with interned strings and lasso (dependency is exposed so you have to understand this) - https://github.com/conradludgate/measured/issues/1
- complexity dealing with [labelgroup derive](https://docs.rs/measured/latest/measured/derive.LabelGroup.html) creating hidden structs with different names (confused me the most when migrating) - https://github.com/conradludgate/measured/issues/3
- reflection for getting values for unit tests are a little awkward / but on plus side no registries!
- protobuf WIP: https://github.com/conradludgate/measured/commit/3b4a4402d0a003ca420542592df1935a650466be
- not sure if it is compatible with openmetrics format ([only encoder](https://github.com/conradludgate/measured/blob/main/core/src/text.rs))
- no exemplar support ([exists in the official](https://docs.rs/prometheus-client/latest/prometheus_client/metrics/exemplar/struct.HistogramWithExemplars.html), requires openmetrics) - only [loosely referenced in generated protobuf code](https://github.com/search?q=repo%3Aconradludgate%2Fmeasured%20exemplar&type=code) - https://github.com/conradludgate/measured/issues/4
- does not build upon the [official client](https://github.com/prometheus/client_rust) so uncertain if future/potential  `native histogram` would be propagated (but from benchmarks the official client is also not great...)

I believe opemetrics text format with exemplars could be easily retrofitted on top of `measured`, so maybe that's a way forward.