### PR TITLE
Try out offficial `prometheus_client` for metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
  "kube",
  "opentelemetry",
  "opentelemetry-otlp",
- "prometheus",
+ "prometheus-client",
  "schemars",
  "serde",
  "serde_json",
@@ -690,6 +690,12 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "dtoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
 name = "dyn-clone"
@@ -1777,18 +1783,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.13.3"
+name = "prometheus-client"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+checksum = "c1ca959da22a332509f2a73ae9e5f23f9dcfc31fd3a54d71f159495bd5909baa"
 dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
+ "dtoa",
+ "itoa",
  "parking_lot",
- "protobuf",
- "thiserror",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1813,12 +1827,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ schemars = { version = "0.8.12", features = ["chrono"] }
 serde = { version = "1.0.185", features = ["derive"] }
 serde_json = "1.0.105"
 serde_yaml = "0.9.25"
-prometheus = "0.13.3"
 chrono = { version = "0.4.26", features = ["serde"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
@@ -44,6 +43,7 @@ opentelemetry-otlp = { version = "0.13.0", features = ["tokio"], optional = true
 tonic = { version = "0.9", optional = true }
 thiserror = "1.0.47"
 anyhow = "1.0.75"
+prometheus-client = "0.22.2"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ generate:
 
 # run with opentelemetry
 run-telemetry:
-  OPENTELEMETRY_ENDPOINT_URL=http://127.0.0.1:55680 RUST_LOG=info,kube=trace,controller=debug cargo run --features=telemetry
+  OPENTELEMETRY_ENDPOINT_URL=http://127.0.0.1:55680 RUST_LOG=info,kube=debug,controller=debug cargo run --features=telemetry
 
 # run without opentelemetry
 run:

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -172,7 +172,7 @@ pub struct State {
     /// Diagnostics populated by the reconciler
     diagnostics: Arc<RwLock<Diagnostics>>,
     /// Metrics registry
-    registry: prometheus::Registry,
+    registry: Registry,
 }
 
 /// State wrapper around the controller outputs for the web server

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -60,7 +60,7 @@ pub struct Context {
 async fn reconcile(doc: Arc<Document>, ctx: Arc<Context>) -> Result<Action> {
     let trace_id = telemetry::get_trace_id();
     Span::current().record("trace_id", &field::display(&trace_id));
-    let _timer = ctx.metrics.reconciler.count_and_measure();
+    let _timer = ctx.metrics.reconciler.count_and_measure(&trace_id);
     ctx.diagnostics.write().await.last_event = Utc::now();
     let ns = doc.namespace().unwrap(); // doc is namespace scoped
     let docs: Api<Document> = Api::namespaced(ctx.client.clone(), &ns);

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -1,9 +1,8 @@
 //! Helper methods only available for tests
-use crate::{Context, Document, DocumentSpec, DocumentStatus, Metrics, Result, DOCUMENT_FINALIZER};
+use crate::{Context, Document, DocumentSpec, DocumentStatus, Result, DOCUMENT_FINALIZER};
 use assert_json_diff::assert_json_include;
 use http::{Request, Response};
 use kube::{client::Body, Client, Resource, ResourceExt};
-use prometheus::Registry;
 use std::sync::Arc;
 
 impl Document {
@@ -208,15 +207,14 @@ impl ApiServerVerifier {
 
 impl Context {
     // Create a test context with a mocked kube client, locally registered metrics and default diagnostics
-    pub fn test() -> (Arc<Self>, ApiServerVerifier, Registry) {
+    pub fn test() -> (Arc<Self>, ApiServerVerifier) {
         let (mock_service, handle) = tower_test::mock::pair::<Request<Body>, Response<Body>>();
         let mock_client = Client::new(mock_service, "default");
-        let registry = Registry::default();
         let ctx = Self {
             client: mock_client,
-            metrics: Metrics::default().register(&registry).unwrap(),
+            metrics: Arc::default(),
             diagnostics: Arc::default(),
         };
-        (Arc::new(ctx), ApiServerVerifier(handle), registry)
+        (Arc::new(ctx), ApiServerVerifier(handle))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@ pub use controller::{self, telemetry, State};
 #[get("/metrics")]
 async fn metrics(c: Data<State>, _req: HttpRequest) -> impl Responder {
     let metrics = c.metrics();
-    HttpResponse::Ok().body(metrics)
+    HttpResponse::Ok()
+        .content_type("application/openmetrics-text; version=1.0.0; charset=utf-8")
+        .body(metrics)
 }
 
 #[get("/health")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,11 @@
 #![allow(unused_imports, unused_variables)]
 use actix_web::{get, middleware, web::Data, App, HttpRequest, HttpResponse, HttpServer, Responder};
 pub use controller::{self, telemetry, State};
-use prometheus::{Encoder, TextEncoder};
 
 #[get("/metrics")]
 async fn metrics(c: Data<State>, _req: HttpRequest) -> impl Responder {
     let metrics = c.metrics();
-    let encoder = TextEncoder::new();
-    let mut buffer = vec![];
-    encoder.encode(&metrics, &mut buffer).unwrap();
-    HttpResponse::Ok().body(buffer)
+    HttpResponse::Ok().body(metrics)
 }
 
 #[get("/health")]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -16,7 +16,7 @@ pub struct Metrics {
 
 impl Default for Metrics {
     fn default() -> Self {
-        let mut registry = Registry::with_prefix("doc_ctrl_");
+        let mut registry = Registry::with_prefix("doc_ctrl");
         let reconciler = Reconciler::default().register(&mut registry);
         Self {
             registry: Arc::new(registry),
@@ -52,18 +52,18 @@ impl Reconciler {
     /// Register API metrics to start tracking them.
     pub fn register(self, registry: &mut Registry) -> Self {
         registry.register_with_unit(
-            "doc_controller_ reconcile_duration_seconds",
+            "reconcile_duration_seconds",
             "The duration of reconcile to complete in seconds",
             Unit::Seconds,
             self.reconcile_duration.clone(),
         );
         registry.register(
-            "doc_controller_reconciliation_errors_total",
+            "reconciliation_errors_total",
             "reconciliation errors",
             self.failures.clone(),
         );
         registry.register(
-            "doc_controller_reconciliations_total",
+            "reconciliations_total",
             "reconciliations",
             self.reconciliations.clone(),
         );


### PR DESCRIPTION
A working POC for [prometheus/client_rust](https://github.com/prometheus/client_rust) ripping out [tikv/rust-prometheus](https://github.com/tikv/rust-prometheus). Not much easier than `measured` (via #71) because the documentation is lackluster, but the codebase ends up being slightly nicer (and proc macro stuff less confusing for sure).

PROS:
- similar conventions to what everyone is used to from the tikv crate
- [Family<ErrorLabels, Counter> style generics](https://docs.rs/prometheus-client/latest/prometheus_client/metrics/family/struct.Family.html) works well and is easy to setup
- exemplar support present and working (using it for reconcile duration histogram)
- [Registry::with_prefix](https://docs.rs/prometheus-client/latest/prometheus_client/registry/struct.Registry.html#method.with_prefix) that allows sharing of metrics modules
- [Unit support in help strings](https://docs.rs/prometheus-client/latest/prometheus_client/registry/struct.Registry.html#method.register_with_unit) nice minor thing

CONS:
- barebones, [one real example in docs](https://docs.rs/prometheus-client/latest/prometheus_client/index.html)
- necessary manual arc wrapping of registries - was undocumented and had to apply `measured`'s patterns manually
- [minimal](https://github.com/prometheus/client_rust/blob/master/src/encoding/protobuf.rs) protobuf support [out-of-date >7mo](https://github.com/prometheus/client_rust/pull/182), barely tested ([all examples](https://github.com/prometheus/client_rust/tree/master/examples) use text encoder), [undocumented in crate docs](https://docs.rs/prometheus-client/latest/prometheus_client/metrics/index.html?search=proto), doesn't integrate with frameworks as prost is out of date (e.g. [actix-protobuf has prost@0.12](https://github.com/actix/actix-extras/tree/master/actix-protobuf))
- 1 documented exported [encoder](https://docs.rs/prometheus-client/latest/prometheus_client/encoding/index.html) returns a `String`
- [benchmarks from measured](https://github.com/conradludgate/measured?tab=readme-ov-file#benchmark-results) makes this look awful in comparison [despite their goals](https://github.com/prometheus/client_rust?tab=readme-ov-file#goals)
- also minimally maintained: https://github.com/prometheus/client_rust/issues - not even merging passing dependabot prs
- nit: not really qualify a client.

This is not updated well enough that I would be comfortable using it. If it had working protobuf and maybe native histograms or something this would be worth talking about, but it's only really bringing some slight ergonomics + exemplars to the table, that's useless if they don't update depedendencies. We don't have to choose this. There's no major downside for using an unofficial metrics crate if offical upstream is just a collection of unoptimized structs putting `client` in its name to make itself seem important.