### PR TITLE
e2e ci should use built image in e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             type=pep440,pattern={{version}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=pr
-            type=raw,value=test,enable=${{ !endsWith(github.ref, 'main')
+            type=raw,value=test,enable=${{ !endsWith(github.ref, '/main')}}
 
       - name: Docker login on main origin
         uses: docker/login-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,10 +162,10 @@ jobs:
         with:
           name: controller-image
           path: /tmp
-      - name: Load docker image from tarball
-        run: docker load --input /tmp/image.tar
+      # - name: Load docker image from tarball
+        # run: docker load --input /tmp/image.tar
       - name: Load image into k3d registry
-        run: k3d image import ghcr.io/kube-rs/controller:latest --cluster kube
+        run: k3d image import /tmp/image.tar --cluster kube
       - name: helm template | kubctl apply
         run: |
           apiserver="$(kubectl get endpoints kubernetes -ojson | jq '.subsets[0].addresses[0].ip' -r)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             type=pep440,pattern={{version}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=pr
-            type=raw,value=test,enable={{is_default_branch != true}}
+            type=raw,value=test,enable=${{ !endsWith(github.ref, 'main')
 
       - name: Docker login on main origin
         uses: docker/login-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
         with:
           version: v1.31
           k3d-name: kube
-          k3d-args: "--no-lb --no-rollback --registry-create 'reg' --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
+          k3d-args: "--no-lb --no-rollback --registry-create reg --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
       - run: kubectl apply -f yaml/crd.yaml
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -164,6 +164,8 @@ jobs:
           path: /tmp
       - name: Load docker image from tarball
         run: docker load --input /tmp/image.tar
+      - name: Load image into k3d registry
+        run: k3d image import ghcr.io/kube-rs/controller:latest --cluster kube
       - name: helm template | kubctl apply
         run: |
           apiserver="$(kubectl get endpoints kubernetes -ojson | jq '.subsets[0].addresses[0].ip' -r)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
             type=pep440,pattern={{version}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=pr
+            type=raw,value=test,enable={{is_default_branch != true}}
 
       - name: Docker login on main origin
         uses: docker/login-action@v3
@@ -165,12 +166,12 @@ jobs:
       # - name: Load docker image from tarball
         # run: docker load --input /tmp/image.tar
       - name: Load image into k3d registry
-        run: k3d image import /tmp/image.tar --cluster kube
+        run: k3d image import /tmp/image.tar --cluster kube --verbose
       - name: helm template | kubctl apply
         run: |
           apiserver="$(kubectl get endpoints kubernetes -ojson | jq '.subsets[0].addresses[0].ip' -r)"
           helm template charts/doc-controller \
-            --set version=latest \
+            --set version=test \
             --set networkPolicy.enabled=true \
             --set networkPolicy.apiserver.0=${apiserver}/32 \
             | kubectl apply -f -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,9 +151,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.27
+          version: v1.31
           k3d-name: kube
-          k3d-args: "--no-lb --no-rollback --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
+          k3d-args: "--no-lb --no-rollback --registry-create --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
       - run: kubectl apply -f yaml/crd.yaml
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
         with:
           version: v1.31
           k3d-name: kube
-          k3d-args: "--no-lb --no-rollback --registry-create --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
+          k3d-args: "--no-lb --no-rollback --registry-create 'reg' --k3s-arg --disable=traefik,servicelb,metrics-server@server:*"
       - run: kubectl apply -f yaml/crd.yaml
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
currently it pulls it from the registry's :latest.