### PR TITLE
Bump prometheus-client to 0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
+checksum = "e4500adecd7af8e0e9f4dbce15cfee07ce913fbf6ad605cc468b83f2d531ee94"
 dependencies = [
  "dtoa",
  "itoa",
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client-derive-encode"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ opentelemetry-otlp = { version = "0.30", optional = true, default-features = fal
 opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }
 thiserror = "2.0.12"
 anyhow = "1.0.99"
-prometheus-client = "0.23.1"
+prometheus-client = "0.24.0"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -113,6 +113,7 @@ impl Drop for ReconcileMeasurer {
         #[allow(clippy::cast_precision_loss)]
         let duration = self.start.elapsed().as_millis() as f64 / 1000.0;
         let labels = self.labels.take();
-        self.metric.observe(duration, labels);
+        self.metric
+            .observe(duration, labels, Some(std::time::SystemTime::now()));
     }
 }


### PR DESCRIPTION
fixes the breaking interface change in exemplars confusing dependabot.
closes https://github.com/kube-rs/controller-rs/pull/178